### PR TITLE
Feature decoratable service

### DIFF
--- a/src/Command/ShareBasketCleanupCommand.php
+++ b/src/Command/ShareBasketCleanupCommand.php
@@ -3,7 +3,7 @@
 namespace Frosh\ShareBasket\Command;
 
 use Frosh\ShareBasket\Core\Content\ShareBasket\ShareBasketDefinition;
-use Frosh\ShareBasket\Services\ShareBasketService;
+use Frosh\ShareBasket\Services\ShareBasketServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,11 +13,11 @@ class ShareBasketCleanupCommand extends Command
     protected static $defaultName = 'frosh:share-basket-cleanup';
 
     /**
-     * @var ShareBasketService
+     * @var ShareBasketServiceInterface
      */
     private $shareBasketService;
 
-    public function __construct(ShareBasketService $shareBasketService)
+    public function __construct(ShareBasketServiceInterface $shareBasketService)
     {
         parent::__construct();
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -30,6 +30,7 @@
             <argument id="sales_channel.product.repository" type="service"/>
             <argument id="Shopware\Core\System\SystemConfig\SystemConfigService" type="service"/>
         </service>
+        <service id="Frosh\ShareBasket\Services\ShareBasketServiceInterface" alias="Frosh\ShareBasket\Services\ShareBasketService" />
 
     </services>
 </container>

--- a/src/ScheduledTask/ShareBasketCleanupTaskHandler.php
+++ b/src/ScheduledTask/ShareBasketCleanupTaskHandler.php
@@ -2,20 +2,20 @@
 
 namespace Frosh\ShareBasket\ScheduledTask;
 
-use Frosh\ShareBasket\Services\ShareBasketService;
+use Frosh\ShareBasket\Services\ShareBasketServiceInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 
 class ShareBasketCleanupTaskHandler extends ScheduledTaskHandler
 {
     /**
-     * @var ShareBasketService
+     * @var ShareBasketServiceInterface
      */
     private $shareBasketService;
 
     public function __construct(
         EntityRepositoryInterface $scheduledTaskRepository,
-        ShareBasketService $shareBasketService
+        ShareBasketServiceInterface $shareBasketService
     ) {
         parent::__construct($scheduledTaskRepository);
         $this->shareBasketService = $shareBasketService;

--- a/src/Services/ShareBasketService.php
+++ b/src/Services/ShareBasketService.php
@@ -87,9 +87,8 @@ class ShareBasketService implements ShareBasketServiceInterface
         $this->systemConfigService = $systemConfigService;
     }
 
-    public function saveCart(SalesChannelContext $salesChannelContext): ?string
+    public function saveCart(array $data, SalesChannelContext $salesChannelContext): ?string
     {
-        $data = $this->prepareLineItems($salesChannelContext);
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('salesChannelId', $salesChannelContext->getSalesChannel()->getId()));
         $criteria->addFilter(new EqualsFilter('hash', $data['hash']));

--- a/src/Services/ShareBasketServiceInterface.php
+++ b/src/Services/ShareBasketServiceInterface.php
@@ -9,15 +9,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 interface ShareBasketServiceInterface
 {
-    /**
-     * @return bool|string
-     */
-    public function saveCart(SalesChannelContext $context);
+    public function saveCart(array $data, SalesChannelContext $context): ?string;
 
-    /**
-     * @return bool|Cart
-     */
-    public function loadCart(Request $request, SalesChannelContext $context);
+    public function loadCart(Request $request, SalesChannelContext $context): ?Cart;
 
     public function prepareLineItems(SalesChannelContext $context): array;
 

--- a/src/Storefront/Controller/ShareBasketController.php
+++ b/src/Storefront/Controller/ShareBasketController.php
@@ -2,7 +2,7 @@
 
 namespace Frosh\ShareBasket\Storefront\Controller;
 
-use Frosh\ShareBasket\Services\ShareBasketService;
+use Frosh\ShareBasket\Services\ShareBasketServiceInterface;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
@@ -16,11 +16,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class ShareBasketController extends StorefrontController
 {
     /**
-     * @var ShareBasketService
+     * @var ShareBasketServiceInterface
      */
     private $shareBasketService;
 
-    public function __construct(ShareBasketService $shareBasketService)
+    public function __construct(ShareBasketServiceInterface $shareBasketService)
     {
         $this->shareBasketService = $shareBasketService;
     }

--- a/src/Storefront/Controller/ShareBasketController.php
+++ b/src/Storefront/Controller/ShareBasketController.php
@@ -31,7 +31,8 @@ class ShareBasketController extends StorefrontController
     public function save(SalesChannelContext $context): Response
     {
         try {
-            $froshShareBasketUrl = $this->shareBasketService->saveCart($context);
+            $data = $this->shareBasketService->prepareLineItems($context);
+            $froshShareBasketUrl = $this->shareBasketService->saveCart($data, $context);
             $froshShareBasketState = 'cartSaved';
         } catch (\Exception $exception) {
             $froshShareBasketState = 'cartError';

--- a/src/Storefront/Page/Checkout/Cart/Subscriber/CheckoutPageSubscriber.php
+++ b/src/Storefront/Page/Checkout/Cart/Subscriber/CheckoutPageSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Frosh\ShareBasket\Storefront\Page\Checkout\Cart\Subscriber;
 
-use Frosh\ShareBasket\Services\ShareBasketService;
+use Frosh\ShareBasket\Services\ShareBasketServiceInterface;
 use Shopware\Core\Checkout\Cart\Exception\PayloadKeyNotFoundException;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoadedEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -10,11 +10,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class CheckoutPageSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var ShareBasketService
+     * @var ShareBasketServiceInterface
      */
     private $shareBasketService;
 
-    public function __construct(ShareBasketService $shareBasketService)
+    public function __construct(ShareBasketServiceInterface $shareBasketService)
     {
         $this->shareBasketService = $shareBasketService;
     }
@@ -47,7 +47,7 @@ class CheckoutPageSubscriber implements EventSubscriberInterface
                 if ($hash === $shareBasketData['hash']) {
                     $page->assign([
                         'froshShareBasketState' => 'cartExists',
-                        'froshShareBasketUrl' => $this->shareBasketService->saveCart($event->getSalesChannelContext()),
+                        'froshShareBasketUrl' => $this->shareBasketService->saveCart($shareBasketData, $event->getSalesChannelContext()),
                     ]);
                 }
             } catch (PayloadKeyNotFoundException $e) {


### PR DESCRIPTION
I would like to extend the plugin to make it compatible with SwagCustomizedProducts. Unfortunately while there is an Interface for ShareBasketService, it is not used.

This pull request changes all uses of ShareBasketService to ShareBasketServiceInterface which allows decorators for ShareBasketService.

There is one more issue. If a decorator wants to change prepareLineItems, this decorated function is not used in saveCart. Therefore I changed the signature of saveCart. This would be a breaking change.

Any Feedback would be appreciated.
