### PR TITLE
feat: allow to change criteria before cleaning baskets

### DIFF
--- a/src/Core/Content/ShareBasket/Events/ShareBasketCleanupCriteriaEvent.php
+++ b/src/Core/Content/ShareBasket/Events/ShareBasketCleanupCriteriaEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Frosh\ShareBasket\Core\Content\ShareBasket\Events;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;

--- a/src/Core/Content/ShareBasket/Events/ShareBasketCleanupCriteriaEvent.php
+++ b/src/Core/Content/ShareBasket/Events/ShareBasketCleanupCriteriaEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Frosh\ShareBasket\Core\Content\ShareBasket\Events;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ShareBasketCleanupCriteriaEvent extends Event
+{
+    public function __construct(
+        private readonly Criteria $criteria,
+    )
+    {
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+}

--- a/src/Services/ShareBasketService.php
+++ b/src/Services/ShareBasketService.php
@@ -5,6 +5,7 @@ namespace Frosh\ShareBasket\Services;
 
 use Frosh\ShareBasket\Core\Content\ShareBasket\Aggregate\ShareBasketLineItem\ShareBasketLineItemEntity;
 use Frosh\ShareBasket\Core\Content\ShareBasket\Events\ShareBasketAddLineItemEvent;
+use Frosh\ShareBasket\Core\Content\ShareBasket\Events\ShareBasketCleanupCriteriaEvent;
 use Frosh\ShareBasket\Core\Content\ShareBasket\Events\ShareBasketPrepareLineItemEvent;
 use Frosh\ShareBasket\Core\Content\ShareBasket\ShareBasketDefinition;
 use Frosh\ShareBasket\Core\Content\ShareBasket\ShareBasketEntity;
@@ -166,6 +167,11 @@ class ShareBasketService implements ShareBasketServiceInterface
         ));
 
         $criteria->addAssociation('lineItems');
+
+        $this->eventDispatcher->dispatch(
+            new ShareBasketCleanupCriteriaEvent($criteria),
+            ShareBasketCleanupCriteriaEvent::class
+        );
 
         $shareBasketEntities = $this->shareBasketRepository->searchIds($criteria, Context::createDefaultContext());
 


### PR DESCRIPTION
This PR adds the ShareBasketCleanupCriteriaEvent to change object used in \Frosh\ShareBasket\Services\ShareBasketService::cleanup to save some shared baskets from deletion.