### PR TITLE
fix: typescript typing error of plugin manager

### DIFF
--- a/src/Resources/app/storefront/package-lock.json
+++ b/src/Resources/app/storefront/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@friendsofshopware/storefront-sdk": "^0.1.0"
+        "@friendsofshopware/storefront-sdk": "^0.1.1"
       }
     },
     "node_modules/@friendsofshopware/storefront-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@friendsofshopware/storefront-sdk/-/storefront-sdk-0.1.0.tgz",
-      "integrity": "sha512-k4H1EzVhUwQa+bKQ9dF3IRt9CpprrBjkqSwX+NGltv4Q3SuQuTU0vFBTvMtSEnSowVVjz8gbDcKGFr97doxCBw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@friendsofshopware/storefront-sdk/-/storefront-sdk-0.1.1.tgz",
+      "integrity": "sha512-SyRBxvnB21P7aM9YRqipDCVCYsYlUEeQkVNA98R2HQ0JgVcHXdn8r4LoTFxO4N5iOjbsyScRXVBQQa9MCvlSbg==",
       "dependencies": {
         "deepmerge": "^4.3.1"
       }

--- a/src/Resources/app/storefront/package.json
+++ b/src/Resources/app/storefront/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@friendsofshopware/storefront-sdk": "^0.1.0"
+    "@friendsofshopware/storefront-sdk": "^0.1.1"
   }
 }

--- a/src/Resources/app/storefront/tsconfig.json
+++ b/src/Resources/app/storefront/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "types": ["@friendsofshopware/storefront-sdk"]
+    }
+}


### PR DESCRIPTION
red PluginManager annoys in typescript. so fixed it in storefront sdk

![image](https://github.com/FriendsOfShopware/FroshPlatformShareBasket/assets/6224096/5cbd84c2-ca46-427d-acbd-f38d6f2cd2b0)

![image](https://github.com/FriendsOfShopware/FroshPlatformShareBasket/assets/6224096/d88fcfa4-0bc2-4e72-8936-c2fb75d7897a)
