### PR TITLE
Fixed wrapper

### DIFF
--- a/src/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -1,9 +1,9 @@
 {% sw_extends '@Storefront/storefront/page/checkout/cart/index.html.twig' %}
 
 {% block page_checkout_cart_product_table %}
-    <div class="container mb-3">
+    <div class="mb-3">
         <div class="row">
-            <div class="p-0 col-sm-12 col-md-8 col-lg-6">
+            <div class="col-sm-12 col-md-8 col-lg-6">
 
                 {% if page.froshShareBasketState == 'cartExists' %}
 


### PR DESCRIPTION
Better compatibility with themes. Container ist not needed here.
The column padding was removed even though it's needed for the `.row`
This behavior causes an indentation to the right if third party themes adjust the bootstrap grid gutter width variable or container padding.