### PR TITLE
fix: Properly display alert if not saved carts exist

### DIFF
--- a/src/Core/Content/ShareBasket/ShareBasketDefinition.php
+++ b/src/Core/Content/ShareBasket/ShareBasketDefinition.php
@@ -5,7 +5,6 @@ namespace Frosh\ShareBasket\Core\Content\ShareBasket;
 
 use Frosh\ShareBasket\Core\Content\ShareBasket\Aggregate\ShareBasketCustomer\ShareBasketCustomerDefinition;
 use Frosh\ShareBasket\Core\Content\ShareBasket\Aggregate\ShareBasketLineItem\ShareBasketLineItemDefinition;
-use PxswTheme\WurmB2BSuiteBundle\Core\Content\WurmB2BSuite\B2BSuiteSalesAgent\Aggregate\CustomerSalesAgent\CustomerSalesAgentDefinition;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;

--- a/src/Resources/views/storefront/page/account/saved-carts/index.html.twig
+++ b/src/Resources/views/storefront/page/account/saved-carts/index.html.twig
@@ -6,7 +6,10 @@
 
         {% block page_account_saved_basket_content %}
             {% if froshSavedBaskets|length == 0 %}
-                <p class="alert alert-info">{{ 'frosh-share-basket.noSavedCarts'|trans }}</p>
+                {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                    type: 'info',
+                    content: 'frosh-share-basket.noSavedCarts'|trans
+                } %}
             {% else %}
                 {% for basket in froshSavedBaskets %}
                     <h2>{{ "frosh-share-basket.cartId"|trans({'%cartId%': basket.basketId}) }}</h2>

--- a/src/Services/ShareBasketService.php
+++ b/src/Services/ShareBasketService.php
@@ -7,7 +7,6 @@ use Frosh\ShareBasket\Core\Content\ShareBasket\Aggregate\ShareBasketLineItem\Sha
 use Frosh\ShareBasket\Core\Content\ShareBasket\Events\ShareBasketAddLineItemEvent;
 use Frosh\ShareBasket\Core\Content\ShareBasket\Events\ShareBasketCleanupCriteriaEvent;
 use Frosh\ShareBasket\Core\Content\ShareBasket\Events\ShareBasketPrepareLineItemEvent;
-use Frosh\ShareBasket\Core\Content\ShareBasket\ShareBasketCollection;
 use Frosh\ShareBasket\Core\Content\ShareBasket\ShareBasketDefinition;
 use Frosh\ShareBasket\Core\Content\ShareBasket\ShareBasketEntity;
 use Shopware\Core\Checkout\Cart\Cart;


### PR DESCRIPTION
Missed the styling and unused imports :see_no_evil: 