### PR TITLE
Fix sidebar.html.twig

### DIFF
--- a/src/Resources/views/storefront/page/account/sidebar.html.twig
+++ b/src/Resources/views/storefront/page/account/sidebar.html.twig
@@ -1,4 +1,4 @@
-{% extends '@Storefront/storefront/page/account/sidebar.html.twig' %}
+{% sw_extends '@Storefront/storefront/page/account/sidebar.html.twig' %}
 
 {% block page_account_sidebar_menu_inner %}
     {{ parent() }}


### PR DESCRIPTION
Use 'sw_extends' to enable template inheritance to work properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated template inheritance to use Shopware's custom extension syntax for improved compatibility with the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->